### PR TITLE
Update links

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ import credits from '../lib/credits.json';
 
 			<div class="flex justify-center space-x-8">
 				<a href="https://ios.cfw.guide/installing-palera1n" class="text-black dark:text-white bg-gray-100 dark:bg-gray-900 hover:bg-grey focus:ring-4 focus:ring-blue-300 font-bold rounded-full text-sm px-7 py-4 dark:hover:bg-gray-800 focus:outline-none no-underline transition-[background-color] duration-[0.2s] ease-[ease-in-out]">Get Started</a>
-				<a href="https://github.com/palera1n/palera1n/releases/tag/v2.0.0-beta.6.2" class="text-black dark:text-white bg-gray-100 dark:bg-gray-900 hover:bg-grey focus:ring-4 focus:ring-blue-300 font-bold rounded-full text-sm px-7 py-4 dark:hover:bg-gray-800 focus:outline-none no-underline transition-[background-color] duration-[0.2s] ease-[ease-in-out]">Downloads</a>
+				<a href="https://github.com/palera1n/palera1n/releases/latest" class="text-black dark:text-white bg-gray-100 dark:bg-gray-900 hover:bg-grey focus:ring-4 focus:ring-blue-300 font-bold rounded-full text-sm px-7 py-4 dark:hover:bg-gray-800 focus:outline-none no-underline transition-[background-color] duration-[0.2s] ease-[ease-in-out]">Downloads</a>
 			</div>
 		</div>
 	</div>

--- a/src/pages/latest-release.astro
+++ b/src/pages/latest-release.astro
@@ -78,27 +78,27 @@ import Layout from '../layouts/Default.astro';
 					<!-- Buttons based on useragent -->
 					
 					<div style="display: flex; justify-content: center; align-items: center; margin-top: -20px;">
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-macos-universal" download id="mac-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-macos-universal" download id="mac-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
 							<Icon pack="mdi" name="download" class="fill-gray-800 dark:fill-white h-[1.4em] mr-2" />
 							<span class="text-center">Download for MacOS (CLI, universal)</span>
 						</a>				
 					  
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-linux-x86_64" download id="linux-x86_64-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-linux-x86_64" download id="linux-x86_64-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
 							<Icon pack="mdi" name="download" class="fill-gray-800 dark:fill-white h-[1.4em] mr-2" />
 							<span class="text-center">Download for Linux (CLI, x86_64)</span>
 						</a>
 						
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-linux-arm64" download id="linux-aarch64-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-linux-arm64" download id="linux-aarch64-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
 							<Icon pack="mdi" name="download" class="fill-gray-800 dark:fill-white h-[1.4em] mr-2" />
 							<span class="text-center">Download for Linux (CLI, aarch64)</span>
 						</a>
 						
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-linux-x86" download id="linux-i686-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-linux-x86" download id="linux-i686-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
 							<Icon pack="mdi" name="download" class="fill-gray-800 dark:fill-white h-[1.4em] mr-2" />
 							<span class="text-center">Download for Linux (CLI, i686)</span>
 						</a>
 
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-linux-armel" download id="linux-armel-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-linux-armel" download id="linux-armel-download-button" class="bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 text-gray-800 text-white dark:white rounded-xl p-3 flex flex-row justify-center items-center mt-4 max-w-max hidden">
 							<Icon pack="mdi" name="download" class="fill-gray-800 dark:fill-white h-[1.4em] mr-2" />
 							<span class="text-center">Download for Linux (CLI, armel)</span>
 						</a>
@@ -242,13 +242,13 @@ import Layout from '../layouts/Default.astro';
 			</div>
 					<!-- All Downloads -->
 		<div class="bg-gray-200 dark:bg-gray-800 border-2 border-gray-300 dark:border-gray-600 rounded-2xl p-12 mx-auto text-center">
-			<a href="https://github.com/palera1n/palera1n/releases/tag/v2.0.0-beta.6.2" class="flex items-center justify-center">
+			<a href="https://github.com/palera1n/palera1n/releases/latest" class="flex items-center justify-center">
 				<Icon pack="mdi" name="link-variant" class="fill-gray-800 h-[1.4em] mr-2" />
 				<h5 class="text-3xl font-bold text-black dark:text-white cursor-pointer">All Builds</h5>
 			</a>
 				<div class="justify-start mt-8">
 					<div class="w-full">
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-macos-universal" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-macos-universal" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
 							<Icon pack="mdi" name="download" class="fill-gray-800 h-[1.4em] mr-2" />
 							<span class="text-center">Download for macOS (CLI, universal)</span>
 						</a>
@@ -257,7 +257,7 @@ import Layout from '../layouts/Default.astro';
 
 				<div class="justify-start mt-4">
 					<div class="w-full">
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-linux-x86_64" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-linux-x86_64" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
 							<Icon pack="mdi" name="download" class="fill-gray-800 h-[1.4em] mr-2" />
 							<span class="text-center">Download for Linux (CLI, x86_64)</span>
 						</a>
@@ -266,7 +266,7 @@ import Layout from '../layouts/Default.astro';
 
 				<div class="justify-start mt-4">
 					<div class="w-full">
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-linux-x86" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-linux-x86" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
 							<Icon pack="mdi" name="download" class="fill-gray-800 h-[1.4em] mr-2" />
 							<span class="text-center">Download for Linux (CLI, i486)</span>
 						</a>
@@ -275,7 +275,7 @@ import Layout from '../layouts/Default.astro';
 
 				<div class="justify-start mt-4">
 					<div class="w-full">
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-linux-arm64" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-linux-arm64" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
 							<Icon pack="mdi" name="download" class="fill-gray-800 h-[1.4em] mr-2" />
 							<span class="text-center">Download for Linux (CLI, arm64)</span>
 						</a>
@@ -284,7 +284,7 @@ import Layout from '../layouts/Default.astro';
 
 				<div class="justify-start mt-4">
 					<div class="w-full">
-						<a href="https://github.com/palera1n/palera1n/releases/download/v2.0.0-beta.6.2/palera1n-linux-armel" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
+						<a href="https://github.com/palera1n/palera1n/releases/latest/download/palera1n-linux-armel" download id="mac-download-button" class="w-full bg-gray-400 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 rounded-xl p-2 flex items-center mt-4 md:mt-0 mr-4">
 							<Icon pack="mdi" name="download" class="fill-gray-800 h-[1.4em] mr-2" />
 							<span class="text-center">Download for Linux (CLI, armel)</span>
 						</a>


### PR DESCRIPTION
Make links always take you to the latest release, so you don't have to update the link everytime there's a release.