### PR TITLE
make stars look less jarring

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,7 +9,7 @@ import { Icon } from 'astro-icon'
 
     const stars_element: HTMLElement | null = document.getElementById("stars_element");
     if (stars_element) {
-        stars_element.innerHTML = stars_element.innerHTML.replace('starsHere', stars);
+        stars_element.innerHTML = stars_element.innerHTML.replace('​', stars);
     }
 
     const mobile_menu_button: HTMLElement | null = document.getElementById("mobile_menu_button");
@@ -38,7 +38,7 @@ import { Icon } from 'astro-icon'
             </a>
             <div class="flex items-center lg:order-2">
                 <a href="https://github.com/palera1n/palera1n/stargazers" id="stars_element" class="text-gray-800 dark:text-white hover:bg-gray-50 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800 no-underline inline transition-[background-color] duration-[0.2s] ease-[ease-in-out]">
-                    <Icon pack="mdi" name="star" class="fill-gray-800 dark:fill-white h-[1.4em] inline" /> starsHere
+                    <Icon pack="mdi" name="star" class="fill-gray-800 dark:fill-white h-[1.4em] inline" /> ​
                 </a>
             </div>
             <div class="hidden justify-between items-center w-full lg:flex lg:w-auto lg:left-1/2 lg:-translate-x-1/2 lg:absolute" id="mobile_menu">


### PR DESCRIPTION
when the site loads, it makes a request to get the current number of stars for the project and replaces it with the number. before this (or if it doesn't succeed), "starsHere" is shown. IMO, this looks very jarring; so, instead, we just show the star icon and nothing else prior to the request finishing, which IMO looks much more natural.